### PR TITLE
3.5.* Patch: Remove buildings_simple_allow from allow conditional

### DIFF
--- a/mod/common/buildings/13_building_aquaponics_farm_resource_building_overrides.txt
+++ b/mod/common/buildings/13_building_aquaponics_farm_resource_building_overrides.txt
@@ -19,7 +19,6 @@ building_hydroponics_farm = {
 	}
 
 	allow = {
-		buildings_simple_allow = yes
 	}
 
 	destroy_trigger = {

--- a/mod/common/buildings/building_aquaponics_farm_resource_buildings.txt
+++ b/mod/common/buildings/building_aquaponics_farm_resource_buildings.txt
@@ -18,7 +18,6 @@ building_aquaponics_farm = {
 	}
 
 	allow = {
-		buildings_simple_allow = yes
 	}
 
 	destroy_trigger = {
@@ -153,7 +152,6 @@ building_aquaponics_farm_2 = {
 	}
 
 	allow = {
-		buildings_simple_allow = yes
 	}
 
 	destroy_trigger = {


### PR DESCRIPTION
For some reason this conditional in the allow block stopped the building from being buildable / upgradable on my 3.5 save, when I checked the file being overriden I saw that this conditional was not in the allow block. Sure enough, removing the conditional allowed me to upgrade & build the building without issue.